### PR TITLE
Add Report an Issue button and README guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,20 @@ This is open-source, so improvements can be contributed by anyone through github
 * Submit a pull request (i.e. request your changes be pulled into this version)
 
 
+## Reporting an Issue
+
+Found a bug or have a suggestion? You can report it by creating a GitHub issue:
+
+1. Go to the [Issues page](https://github.com/Maaaaaarrk/pd2_planner/issues)
+2. Click **New issue**
+3. Give your issue a clear, descriptive title
+4. In the description, include:
+   - What you expected to happen
+   - What actually happened
+   - Steps to reproduce the problem (if it's a bug)
+   - Your browser and operating system (if relevant)
+5. Click **Submit new issue**
+
+You can also click the **Report an Issue** button at the bottom of the planner page to go directly to the new issue form.
+
+

--- a/index.html
+++ b/index.html
@@ -972,6 +972,7 @@
 				<a id="unreadonlybutton"
 				   style="display:inline-block; background-image: url('images/blankbutton.png'); background-size: auto; background-position: center; background-repeat: no-repeat; height:36px;width:304px; cursor:pointer; line-height:36px; text-align:center; color:white; font-size: 1.1em;"
 				   onclick="setReadBuild()">Edit Build</a>
+				<a href="https://github.com/Maaaaaarrk/pd2_planner/issues/new" target="_blank" style="text-decoration:none; display:inline-block; background-image: url('images/blankbutton.png'); background-size: auto; background-position: center; background-repeat: no-repeat; height:36px;width:304px; cursor:pointer; line-height:36px; text-align:center; color:white; font-size: 1.1em;">Report an Issue</a>
 				<br/>
 				<br/>
 
@@ -1241,6 +1242,7 @@ l-26 24 14 -25z"></path>
                     </svg>
 					</span>
                 </span>
+
 
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- Adds a **Report an Issue** button next to the Make Build Read-only / Edit Build buttons, linking to the GitHub new issue form
- Adds a **Reporting an Issue** section to the README with step-by-step instructions

Resolves #7

## Test plan
- [ ] Verify the Report an Issue button appears grouped with the other buttons and matches their style
- [ ] Verify clicking it opens the GitHub new issue page in a new tab
- [ ] Verify the README guide renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)