### PR TITLE
Add missing all res corruption to boots

### DIFF
--- a/data/items.js
+++ b/data/items.js
@@ -263,6 +263,7 @@ var corruptions = {	// pdr
 		{name:"+ Life per kill", life_per_kill:3},
 		{name:"+ Mana per kill", mana_per_kill:3},
 		{name:"+ FBR", fbr:10},
+		{name:"+ All Resistances", all_res:8},
 	],
 	belt: [
 		{name:"Belt"},
@@ -415,6 +416,7 @@ var corruptions = {	// pdr
 		{name:"+ Life per kill", life_per_kill:3},
 		{name:"+ Mana per kill", mana_per_kill:3},
 		{name:"+ FBR", fbr:10},
+		{name:"+ All Resistances", all_res:8},
 	],
 	merc_belt: [
 		{name:"merc_belt"},


### PR DESCRIPTION
## Summary
- Added `+ All Resistances (+8)` corruption option to boots and merc_boots
- Max roll of +8 sourced from the [PD2 wiki corruptions page](https://wiki.projectdiablo2.com/wiki/Corruptions) (mid-rarity tier)

Resolves #10

## Test plan
- [ ] Verify "All Resistances" appears in the boots corruption dropdown
- [ ] Verify selecting it correctly applies +8 all res to the character stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)