### PR TITLE
Fix assignment instead of comparison in getAffixLine()

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -4392,7 +4392,7 @@ function getAffixLine(affix, loc, group, subgroup) {
 	else if (loc == "charms") { source = equipped.charms[group]; }
 	else if (loc == "socketables") { source = socketables[group]; if (subgroup != "") { source = socketables[group][subgroup] } }
 	else if (loc == "socketed") { source = socketed[group].totals; }
-	else if (loc = "effects") { source = effects[group]; }
+	else if (loc == "effects") { source = effects[group]; }
 	var affix_line = "";
 //	console.log("affix "+affix+" loc "+ loc+ " group "+group+" subgroup "+ subgroup);
 	var value = source[affix];


### PR DESCRIPTION
## Summary
- Fixed `loc = "effects"` (assignment) to `loc == "effects"` (comparison) in `getAffixLine()` at line 4395 of `data/functions.js`
- The assignment operator caused `loc` to always be overwritten to `"effects"`, meaning the wrong data source was used for affix line lookups when this branch was reached

## Test plan
- [ ] Verify that item tooltips display correct affix values for equipped items, charms, socketables, and socketed items (not just effects)
- [ ] Verify that effect-based affixes (e.g., auras, shrine effects) still display correctly
- [ ] Check that no JavaScript errors appear in the console when hovering over items

🤖 Generated with [Claude Code](https://claude.com/claude-code)