### PR TITLE
Fix changeDifficulty() to apply correct penalties per difficulty

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -319,10 +319,9 @@ function changeDifficulty(diff) {
 	character.difficulty = diff
 	var penalties = ["fRes_penalty", "cRes_penalty", "lRes_penalty", "pRes_penalty", "mRes_penalty"]
 	for (let p = 0; p < penalties.length; p++) {
-	//	if (diff == 1) { character[penalties[p]] = 0 }
-	//	else if (diff == 2) { character[penalties[p]] = 40 }
-		//else if (diff == 3) { character[penalties[p]] = 100 }
-        character[penalties[p]] = 100
+		if (diff == 1) { character[penalties[p]] = 0 }
+		else if (diff == 2) { character[penalties[p]] = 40 }
+		else { character[penalties[p]] = 100 }
 	}
 	//document.getElementById("difficulty"+diff).checked = true
 	updateStats()


### PR DESCRIPTION
## Summary
- Resistance penalties in `changeDifficulty()` were commented out and hardcoded to 100 (Hell difficulty values)
- Restored the conditional branches: Normal (diff=1) sets penalties to 0, Nightmare (diff=2) to 40, Hell (diff=3) to 100
- This was causing Normal and Nightmare characters to incorrectly show Hell-level resistance penalties

## Test plan
- [ ] Select Normal difficulty and verify all resistance penalties show 0
- [ ] Select Nightmare difficulty and verify all resistance penalties show -40
- [ ] Select Hell difficulty and verify all resistance penalties show -100
- [ ] Verify switching between difficulties updates stats correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)