### PR TITLE
Fix null dereference in Maul/Feral Rage effect checks

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -2075,8 +2075,8 @@ function updateAllEffects() {
 		else if (id == "Fists_of_Thunder") { if (equipped.weapon.type != "claw" && equipped.weapon.type != "dagger") { disableEffect(id) } }
 		else if (id == "Fists_of_Ice") { if (equipped.weapon.type != "claw" && equipped.weapon.type != "dagger") { disableEffect(id) } }
 		else if (id == "Frenzy") { if (offhandType != "weapon") { disableEffect(id) } }
-		else if (id == "Maul") { if (effects["Werebear"].info.enabled != 1) { disableEffect(id) } }
-		else if (id == "Feral_Rage") { if (effects["Werewolf"].info.enabled != 1) { disableEffect(id) } }
+		else if (id == "Maul") { if (typeof(effects["Werebear"]) == 'undefined' || effects["Werebear"].info.enabled != 1) { disableEffect(id) } }
+		else if (id == "Feral_Rage") { if (typeof(effects["Werewolf"]) == 'undefined' || effects["Werewolf"].info.enabled != 1) { disableEffect(id) } }
 		else if (id == "Holy_Shield") { if (offhandType != "shield") { disableEffect(id) } }
 		else if (id == "Weapon_Block") { if (equipped.weapon.type != "claw" || equipped.offhand.type != "claw") { disableEffect(id) } }
 	//	else if (id == "Claw_Mastery") { if (equipped.weapon.type != "claw" && equipped.offhand.type != "claw") { disableEffect(id) } else { enableEffect(id) } }


### PR DESCRIPTION
## Summary
- Add null guards for `effects["Werebear"]` and `effects["Werewolf"]` before accessing `.info.enabled`
- Prevents crashes when Maul or Feral Rage effects are active but the corresponding shapeshift effect doesn't exist in the effects object

## Test plan
- [ ] Load a Druid build with Maul but without Werebear active — verify no crash
- [ ] Load a Druid build with Feral Rage but without Werewolf active — verify no crash
- [ ] Load a Druid build with both shapeshift and attack skills — verify they still disable correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)