### PR TITLE
Fix comparison instead of assignment for affix_line reset

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -4429,7 +4429,7 @@ function getAffixLine(affix, loc, group, subgroup) {
 		if (affix == "aura" && (source[affix] == "Lifted Spirit" || source[affix] == "Righteous Fire")) { affix_line = source[affix]+" Aura when Equipped" }
 		if (halt == true) { value_combined = 0 }
 	} else {
-		affix_line == ""; value_combined = 1;
+		affix_line = ""; value_combined = 1;
 		if (affix == "ctc") {
 			for (let i = 0; i < source[affix].length; i++) {
 				var line = source[affix][i][0]+"% chance to cast level "+source[affix][i][1]+" "+source[affix][i][2]+" "+source[affix][i][3];


### PR DESCRIPTION
## Summary
- `affix_line == ""` (comparison) changed to `affix_line = ""` (assignment) in `getAffixLine()`
- Without this fix, stale tooltip text bleeds into ctc/cskill/set_bonuses display lines

## Test plan
- [ ] Verify item tooltips with ctc (chance to cast) properties display correctly
- [ ] Verify charged skill tooltips don't show stale text from previous affix lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)