### PR TITLE
Fix corrupt() subtracting name/base strings from character stats

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -656,7 +656,9 @@ function corrupt(group, val) {
                 stats[old_affix] -= corruptsEquipped[group][old_affix]
             }
         } else if (!isSwap) {
-            character[old_affix] -= corruptsEquipped[group][old_affix]
+            if (old_affix != "name" && old_affix != "base" && typeof character[old_affix] !== 'undefined') {
+                character[old_affix] -= corruptsEquipped[group][old_affix]
+            }
         }
         corruptsEquipped[group][old_affix] = unequipped[old_affix]
     }


### PR DESCRIPTION
## Summary
- Added `name`/`base` key exclusion and `typeof` guard to the non-merc corruption path
- Matches the existing guard on the merc path (line 655)
- Without this, `character.name -= "some string"` produces NaN

## Test plan
- [ ] Apply and remove corruptions on player equipment
- [ ] Verify character name still displays correctly after corruption changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)