### PR TITLE
Fix allowSocket() to respect max_sockets cap

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -4813,6 +4813,7 @@ function allowSocket(event, group) {
 	var isSwap = group.startsWith("swap_");
 	var itemEquipped = isMerc ? mercEquipped[group.slice(5)] : (isSwap ? swapEquipped[group.slice(5)] : equipped[group]);
 	socketed[group].sockets = ~~itemEquipped.sockets + ~~corruptsEquipped[group].sockets
+	if (itemEquipped.max_sockets != null) { socketed[group].sockets = Math.min(socketed[group].sockets, itemEquipped.max_sockets) }
 	var allow = 0;
 	if (socketed[group].sockets > 0 && socketed[group].socketsFilled < socketed[group].sockets) {
 		var name = inv[0].onpickup.split('_')[0];


### PR DESCRIPTION
## Summary
- Added `Math.min(sockets, max_sockets)` cap in `allowSocket()`
- Prevents corruption sockets + base sockets from exceeding item type limit

## Test plan
- [ ] Verify socketing works normally on items within limit
- [ ] Verify items with corruption sockets can't exceed their max_sockets

🤖 Generated with [Claude Code](https://claude.com/claude-code)