### PR TITLE
Fix toggleRunning/toggleParameters called with integer instead of DOM element

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -486,7 +486,7 @@ function loadParams() {
 		}
 		if (param_run == 1) {
 			document.getElementById("running").checked = true
-			toggleRunning(param_run)
+			toggleRunning(document.getElementById("running"))
 			character.running = 1
 		}
 		if (param_quests == 1) {
@@ -500,7 +500,7 @@ function loadParams() {
 		}
 		if (param_url == 1) {
 			document.getElementById("parameters").checked = true
-			toggleParameters(param_url)
+			toggleParameters(document.getElementById("parameters"))
 			// are these needed?
 			settings.parameters = 1
 			params.set('url', ~~settings.parameters)


### PR DESCRIPTION
## Summary
- `toggleRunning(param_run)` → `toggleRunning(document.getElementById("running"))`
- `toggleParameters(param_url)` → `toggleParameters(document.getElementById("parameters"))`
- Fixes these functions always taking the wrong branch due to `(1).checked` being undefined

## Test plan
- [ ] Load a URL with `running=1` and verify defense/movement stats are correct
- [ ] Load a URL with `url=1` and verify shareable URL toggle works

🤖 Generated with [Claude Code](https://claude.com/claude-code)