### PR TITLE
Fix readonly URL param being stripped on page load

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -6290,6 +6290,7 @@ function updateURL() {
 	params.delete('charm')
 	for (charm in equipped.charms) { if (typeof(equipped.charms[charm].name) != 'undefined' && equipped.charms[charm].name != 'none') { params.append('charm', equipped.charms[charm].name) }}
 	
+	if (new URLSearchParams(window.location.search).has('readonly')) { params.set('readonly', 1) }
 	if (settings.parameters == 1) { window.history.replaceState({}, '', `${location.pathname}?${params}`) }
 	
 	// TODO: Shorten URL?


### PR DESCRIPTION
## Summary
- `updateURL()` now preserves the `readonly` param from the original URL
- Previously, sharing a readonly link would lose the readonly protection on refresh

## Test plan
- [ ] Load URL with `readonly=1`, verify param persists in address bar after load
- [ ] Copy URL after load, reload it, verify still readonly

🤖 Generated with [Claude Code](https://claude.com/claude-code)