### PR TITLE
Remove PoD-only charm and pod filtering logic

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -1530,8 +1530,7 @@ function loadItems(group, dropdown, className) {
 						if (group != "charms") { addon = "<option selected>" + "­ ­ ­ ­ " + item.name + "</option>" }
 						else { addon = "<option disabled selected>" + "­ ­ ­ ­ " + item.name + "</option>" }
 					} else {
-						if (typeof(item.pod) != 'undefined') { addon = "" }
-						else if (typeof(item.debug) != 'undefined') { addon = "<option class='dropdown-debug'>" + item.name + "</option>" }
+						if (typeof(item.debug) != 'undefined') { addon = "<option class='dropdown-debug'>" + item.name + "</option>" }
 						else if (typeof(item.rarity) != 'undefined') { addon = "<option class='dropdown-"+item.rarity+"'>" + item.name + "</option>" }
 						else { addon = "<option class='dropdown-unique'>" + item.name + "</option>" }
 					}

--- a/data/items_equipment.js
+++ b/data/items_equipment.js
@@ -948,7 +948,6 @@ ring1: [
  {rarity:"magic", name:"Fine Small Charm of Balance", size:"small", req_level:29, damage_max:3, ar:20, fhr:5, pd2:1},
  {rarity:"magic", name:"Fine Small Charm of Inertia", size:"small", req_level:36, damage_max:3, ar:20, frw:3, pd2:1},
  {rarity:"magic", name:"Fine Small Charm of Vita", size:"small", req_level:39, damage_max:3, ar:20, life:20, pd2:1},
- {rarity:"magic", name:"Pestilent Small Charm of Anthrax", size:"small", req_level:80, pDamage_all:451, pDamage_duration:12, pod:1},
  {rarity:"magic", name:"Ruby Small Charm of Vita", size:"small", req_level:39, fRes:11, life:20, pd2:1},
  {rarity:"magic", name:"Serpent's Small Charm of Vita", size:"small", req_level:40, mana:17, life:20, pd2:1},
  {rarity:"magic", name:"Sapphire Small Charm of Vita", size:"small", req_level:39, cRes:11, life:20, pd2:1},


### PR DESCRIPTION
## Summary
- Removed `Pestilent Small Charm of Anthrax` (pod:1) from items_equipment.js
- Removed `item.pod` filter check from loadItems dropdown builder

## Test plan
- [ ] Verify charm dropdown loads correctly
- [ ] Run existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)