### PR TITLE
Remove vestigial v=PD2 URL parameter

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -357,7 +357,7 @@ function toggleParameters(parameters) {
 		window.history.replaceState({}, '', `${location.pathname}?${params}`)
 	} else {
 		settings.parameters = 0
-		window.history.replaceState({}, '', `${location.pathname}?v=PD2`)
+		window.history.replaceState({}, '', `${location.pathname}`)
 	}
 }
 

--- a/index.html
+++ b/index.html
@@ -1278,7 +1278,6 @@ l-26 24 14 -25z"></path>
 
 		// check URL parameters
 		params = new URLSearchParams(window.location.search);
-		params.set('v', 3)
 		if (params.has('class') == true) {
 			if (classes.includes(params.get('class').toLowerCase()) == true) {
 				initial_class = params.get('class').toLowerCase()


### PR DESCRIPTION
## Summary
- Remove `?v=PD2` from the `replaceState` call in `toggleParameters` (data/functions.js)
- Remove `params.set('v', 3)` from `initial_load()` (index.html)
- These version URL parameters are leftover from when PoD/Vanilla modes existed

## Test plan
- [ ] Load the planner and verify no `?v=` parameter appears in the URL
- [ ] Toggle parameters on/off and confirm the URL updates correctly without `?v=PD2`
- [ ] Load a saved build URL and verify it still parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)