### PR TITLE
Inline game_version constant and remove variable

### DIFF
--- a/data/basic_variables.js
+++ b/data/basic_variables.js
@@ -24,7 +24,6 @@ var monsterID = 2;
 var MAX = 20;				// Highest Skill Hardpoints
 var LIMIT = 60;				// Highest Skill Data
 var RES_CAP = 95;
-var game_version = 3;
 var loaded = 0;
 
 var socketed = {	// Gems/Runes/Jewels Socketed in Equipment

--- a/data/functions.js
+++ b/data/functions.js
@@ -2425,7 +2425,7 @@ function getCharacterInfo() {
 		'getSkillData','getBuffData','getSkillDamage','setSkillAmounts','skill_layout','weapon_frames','wereform_frames','fcr_bp','fcr_bp_alt','fcr_bp_werebear','fcr_bp_werewolf','fhr_bp','fhr_bp_alt','fhr_bp_werebear','fhr_bp_werewolf','fbr_bp','fbr_bp_alt','fbr_bp_werebear','fbr_bp_werewolf',
 		'name','type','rarity','not','only','ctc','cskill','set_bonuses','group','size','upgrade','downgrade','aura','tier','weapon','armor','shield','max_sockets','duration','nonmetal','debug'	// TODO: Prevent item qualities from being added as character qualities
 	];
-	var charInfo = "{version:"+game_version+",character:{";
+	var charInfo = "{version:3,character:{";
 	for (stat in character) {
 		var halt = 0;
 		for (let i = 0; i < not_applicable.length; i++) { if (stat == not_applicable[i]) { halt = 1 } }


### PR DESCRIPTION
## Summary
- Remove the `var game_version = 3` declaration from `basic_variables.js`
- Inline the literal `3` at the single usage site in `functions.js`

## Test plan
- [ ] Save a character and verify the exported string still contains `version:3`
- [ ] Load a previously saved character to confirm version parsing still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)