### PR TITLE
Hide active skills display section

### DIFF
--- a/index.html
+++ b/index.html
@@ -753,7 +753,8 @@
 			<!--		skill details		-->
 			<div class="no_selection" id="skill_details" style="display:none;">
 				<div id="ar_spacing"><br><br><br><br><br><br><br><br></div>
-				<div class="gray" id="skill_details_active">
+				<!-- Intentionally hidden - kept for potential future use -->
+				<div class="gray" id="skill_details_active" style="display:none;">
 					<div id="skill_details_basic">
 						<div id="mainhand_basic"><a>Basic Attack: </a><a id="basic_attack"></a><br></div>
 						<div id="offhand_basic"> ­ ­ ­ ­ ­ ­ ­ Offhand: <a id="offhand_basic_damage"></a><br></div>


### PR DESCRIPTION
## Summary
- Hide the `skill_details_active` div with `style="display:none;"` instead of removing it from the DOM
- Add HTML comment explaining the section is intentionally hidden for potential future use

## Test plan
- [ ] Verify the active skills section (basic attack, skill details) is no longer visible in the skill panel
- [ ] Verify the hidden div still exists in the DOM (inspect element) for future reactivation

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)