### PR TITLE
Fix Iron Skin not using effective skill level for PDR

### DIFF
--- a/data/skills/PD2/barbarian.js
+++ b/data/skills/PD2/barbarian.js
@@ -49,7 +49,7 @@ var character_pd2_barbarian = {class_name:"Barbarian", strength:30, dexterity:20
 		var lvl = skill.level + skill.extra_levels;
 		var result = {};
 
-		if (skill.name == "Iron Skin") { result.pdr = skill.data.values[0][skill.level]; }
+		if (skill.name == "Iron Skin") { result.pdr = skill.data.values[0][lvl]; }
 		if (skill.name == "Natural Resistance") { result.resistance_skillup = skill.data.values[0][lvl]; }
 
 	return result


### PR DESCRIPTION
## Summary
- Fix bug where Iron Skin used `skill.level` (base level) instead of `lvl` (base + extra_levels) for physical damage reduction calculation
- This caused +skills from gear to be ignored for Iron Skin's PDR, unlike Natural Resistance which already used `lvl` correctly

## Test plan
- [ ] Equip gear with +barbarian skills or +all skills on a barbarian with Iron Skin
- [ ] Verify the Physical Damage Reduction value now reflects the effective skill level (base + bonus levels) instead of just the base level

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)