### PR TITLE
Add item code display to equipment tooltip

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -3774,6 +3774,8 @@ function itemHover(ev, id) {
 	document.getElementById("item_name").style.color = colors[color]
 	document.getElementById("item_name").innerHTML = name+base
 	document.getElementById("item_info").innerHTML = main_affixes
+	var itemCodeEl = document.getElementById("item_code");
+	if (itemCodeEl) { itemCodeEl.innerHTML = ""; }
 	document.getElementById("item_corruption").innerHTML = ""
 	document.getElementById("item_affixes").innerHTML = affixes
 	document.getElementById("item_set_affixes").innerHTML = ""
@@ -3992,6 +3994,15 @@ function equipmentHoverMerc(group) {
 	}
 	document.getElementById("item_name").innerHTML = name+sock+base+runeword
 	document.getElementById("item_info").innerHTML = main_affixes
+	var itemCodeEl = document.getElementById("item_code");
+	if (itemCodeEl) {
+		var itemObj = mercEquipped[group];
+		if (itemObj && itemObj.code) {
+			itemCodeEl.innerHTML = "Item code: " + itemObj.code;
+		} else {
+			itemCodeEl.innerHTML = "";
+		}
+	}
 	document.getElementById("item_corruption").innerHTML = corruption
 	document.getElementById("item_affixes").innerHTML = affixes
 	document.getElementById("item_set_affixes").innerHTML = set_affixes
@@ -4108,6 +4119,15 @@ function equipSwapHover(group) {
 
 	document.getElementById("item_name").innerHTML = name+sock+base+runeword
 	document.getElementById("item_info").innerHTML = main_affixes
+	var itemCodeEl = document.getElementById("item_code");
+	if (itemCodeEl) {
+		var itemObj = swapEquipped[group];
+		if (itemObj && itemObj.code) {
+			itemCodeEl.innerHTML = "Item code: " + itemObj.code;
+		} else {
+			itemCodeEl.innerHTML = "";
+		}
+	}
 	document.getElementById("item_corruption").innerHTML = corruption
 	document.getElementById("item_affixes").innerHTML = affixes
 	document.getElementById("item_set_affixes").innerHTML = ""
@@ -4326,6 +4346,15 @@ function equipmentHover(group) {
 	}
 	document.getElementById("item_name").innerHTML = name+sock+base+runeword
 	document.getElementById("item_info").innerHTML = main_affixes
+	var itemCodeEl = document.getElementById("item_code");
+	if (itemCodeEl) {
+		var itemObj = equipped[group];
+		if (itemObj && itemObj.code) {
+			itemCodeEl.innerHTML = "Item code: " + itemObj.code;
+		} else {
+			itemCodeEl.innerHTML = "";
+		}
+	}
 	document.getElementById("item_corruption").innerHTML = corruption
 	document.getElementById("item_affixes").innerHTML = affixes
 	document.getElementById("item_set_affixes").innerHTML = set_affixes

--- a/index.html
+++ b/index.html
@@ -134,6 +134,7 @@
 		<div class="hover" id="tooltip_inventory">
 			<a id="item_name" class="tooltip_item"></a>
 			<a id="item_info" class="tooltip_item"></a>
+			<a id="item_code" class="tooltip_item" style="color:gray;font-size:0.85em;"></a>
 			<a id="item_corruption" class="tooltip_item"></a>
 			<a id="item_affixes" class="tooltip_item"></a>
 			<a id="item_set_affixes" class="tooltip_item"></a>


### PR DESCRIPTION
## Summary
- Adds a new `item_code` element to the inventory tooltip HTML, positioned between `item_info` and `item_corruption`, styled in gray at 0.85em font size
- Adds display logic in `equipmentHover`, `equipmentHoverMerc`, and `equipSwapHover` to show "Item code: <code>" when an item has a `code` property
- Clears the item code element in `itemHover` (charms/socketables) to prevent stale tooltip data
- Note: Current items in `items_equipment.js` do not have a `code` property, so the field will remain empty until item codes are added to the data

Closes #52

## Test plan
- [ ] Hover over equipped items and verify the tooltip renders without errors
- [ ] Confirm the item_code line is blank for items without a `code` property (all current items)
- [ ] Manually add a `code: "abc"` property to a test item in `items_equipment.js` and verify "Item code: abc" appears in the tooltip
- [ ] Hover over charms/socketables and verify no stale item code text appears
- [ ] Test merc equipment tooltips and weapon swap tooltips

🤖 Generated with [Claude Code](https://claude.com/claude-code)