### PR TITLE
Hide auras/passives side panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -1238,7 +1238,8 @@ l-26 24 14 -25z"></path>
 
 
 		</div>    <!-- /interface -->
-		<div id="side"></div>
+		<!-- Intentionally hidden - auras/passives side panel kept for potential future use -->
+		<div id="side" style="display:none;"></div>
 		<div id="controls_guide">
 			<div style="font-size:1.4em; margin-bottom:6px; margin-left:12px;">Controls</div>
 			<ul style="margin:0; padding-left:16px;">


### PR DESCRIPTION
## Summary
- Hides the `#side` div that displays active effects (auras, passives)
- Was supposed to be hidden in PD2 mode by the old `changeVersion()` but lost during cleanup

## Test plan
- [ ] Verify auras/passives panel no longer visible on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)