### PR TITLE
Fix #78: Skip merc groups in upgrade/downgrade loops to fix URL item loading

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -530,13 +530,13 @@ function loadParams() {
 					corrupt(group,param_equipped[group][2])
 				} }
 				for (group in corruptsEquipped) {	// upgrades & downgrades
-					if (group.startsWith("swap_")) { continue; }
+					if (group.startsWith("swap_") || group.startsWith("merc_")) { continue; }
 					var baseDiff = ~~param_equipped[group][1] - ~~equipped[group].tier;
 					if (baseDiff < 0) { changeBase(group, "downgrade"); equipmentOut() }
 					if (baseDiff > 0) { changeBase(group, "upgrade"); equipmentOut() }
 				}
 				for (group in corruptsEquipped) {	// upgrades & downgrades (duplicated)
-					if (group.startsWith("swap_")) { continue; }
+					if (group.startsWith("swap_") || group.startsWith("merc_")) { continue; }
 					var baseDiff = ~~param_equipped[group][1] - ~~equipped[group].tier;
 					if (baseDiff < 0) { changeBase(group, "downgrade"); equipmentOut(); }
 					if (baseDiff > 0) { changeBase(group, "upgrade"); equipmentOut(); }
@@ -2633,11 +2633,13 @@ function setCharacterInfo(className) {
 		corrupt(group,fileInfo.corruptsEquipped[group].name)
 	}
 	for (group in corruptsEquipped) {	// upgrades & downgrades
+		if (group.startsWith("swap_") || group.startsWith("merc_")) { continue; }
 		var baseDiff = ~~fileInfo.equipped[group].tier - ~~equipped[group].tier;
 		if (baseDiff < 0) { changeBase(group, "downgrade"); equipmentOut(); }
 		if (baseDiff > 0) { changeBase(group, "upgrade"); equipmentOut(); }
 	}
 	for (group in corruptsEquipped) {	// upgrades & downgrades (duplicated)
+		if (group.startsWith("swap_") || group.startsWith("merc_")) { continue; }
 		var baseDiff = ~~fileInfo.equipped[group].tier - ~~equipped[group].tier;
 		if (baseDiff < 0) { changeBase(group, "downgrade"); equipmentOut(); }	// duplicated (things break for some reason when a while/for loop is used instead)
 		if (baseDiff > 0) { changeBase(group, "upgrade"); equipmentOut(); }		// duplicated (things break for some reason when a while/for loop is used instead)


### PR DESCRIPTION
Closes #78

## Summary
- The upgrade/downgrade loops in `loadParams()` and the file-loading function iterate over all `corruptsEquipped` groups, which includes `merc_` prefixed keys (merc_helm, merc_armor, etc.)
- The `equipped` object does not contain `merc_` keys, so accessing `equipped["merc_helm"].tier` throws a `TypeError` that halts `loadParams()` execution entirely
- This prevents all items loaded **after** the crash point from being restored: mercenary gear, effects, and charms are all lost
- The fix adds a `group.startsWith("merc_")` skip (matching the existing `swap_` skip pattern) in both the URL-loading and file-loading upgrade/downgrade loops

## Test plan
- [ ] Open the URL from issue #78 and verify all equipment, mercenary items, effects, and charms load correctly
- [ ] Verify that item tier upgrades/downgrades still work correctly for player equipment when loading from URL
- [ ] Verify file save/load still handles upgrades/downgrades correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)