### PR TITLE
Fix d2s export class inference error

### DIFF
--- a/data/export_d2s.js
+++ b/data/export_d2s.js
@@ -394,12 +394,11 @@ function buildRipJson() {
 		["Energy", (character.starting_energy || 0) + (character.energy_added || 0)]
 	];
 
-	// Add skills with levels > 0
+	// Add skills - include all class skills so the external tool can
+	// determine the character class even when no skill points are allocated
 	if (typeof skills !== 'undefined') {
 		for (var s = 0; s < skills.length; s++) {
-			if (skills[s].level > 0) {
-				stats.push([skills[s].name, skills[s].level]);
-			}
+			stats.push([skills[s].name, skills[s].level]);
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Fixes the "cannot infer class from skills" error when exporting to .d2s via the external tool
- The external tool's `determineClass()` method requires at least one class-specific skill in the stats array to identify the character class
- Previously, `buildRipJson()` only included skills with `level > 0`, so if no skill points were allocated, the skills array was empty and class detection failed
- Now all class skills are included in the export regardless of level, allowing the external tool to always determine the character class

Closes #82

## Test plan

- [ ] Create a new character in the planner without allocating any skill points
- [ ] Click "Export to Game File" and verify the export tool no longer shows "cannot infer class from skills"
- [ ] Create a character with skill points allocated and verify the export still works correctly
- [ ] Verify the generated .d2s file loads properly in-game

🤖 Generated with [Claude Code](https://claude.com/claude-code)