### PR TITLE
Fix d2s export failing on placeholder skills

### DIFF
--- a/data/export_d2s.js
+++ b/data/export_d2s.js
@@ -395,10 +395,13 @@ function buildRipJson() {
 	];
 
 	// Add skills - include all class skills so the external tool can
-	// determine the character class even when no skill points are allocated
+	// determine the character class even when no skill points are allocated.
+	// Skip placeholder skills (e.g. "None") that the external tool cannot map.
 	if (typeof skills !== 'undefined') {
 		for (var s = 0; s < skills.length; s++) {
-			stats.push([skills[s].name, skills[s].level]);
+			if (skills[s].name && skills[s].name !== "None") {
+				stats.push([skills[s].name, skills[s].level]);
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes #84

## Summary
- The external export tool (bug-free-eureka) throws `unable to map skill: None` when processing the planner's exported JSON, because placeholder "None" skills from the skill tree are included in the stats array
- These "None" placeholders exist in the amazon, assassin, and sorceress skill trees as unused skill slots (marked `/*TODO: remove*/` in the source)
- Filter out skills named "None" during d2s export so the external tool can successfully parse the character data and generate the .d2s save file

## Test plan
- [ ] Load the example URL from issue #84 (sorceress build with Mang Song's Lesson)
- [ ] Click "Export to Game File (.d2s)"
- [ ] Verify the external tool opens and the JSON is accepted without errors
- [ ] Test with amazon and assassin builds (which also have "None" placeholder skills)
- [ ] Verify the downloaded .d2s file loads correctly in-game

🤖 Generated with [Claude Code](https://claude.com/claude-code)