### PR TITLE
Fix #86: Show class-restricted weapons for all classes

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -1489,27 +1489,6 @@ function loadItems(group, dropdown, className) {
 			var item = equipment[group][itemNew];
 			// || item.only == className) {
 				var halt = 0;
-				if(typeof(item.only) != 'undefined'){
-                     if(item.only != className){
-                   //  console.log ("item.only "+item.only+" "+className)
-                        halt = 1;
-                        if (className == "Barb (merc)" && item.only  == "barbarian"){
-                            halt = 0;
-                        }
-                        if (className == "Rogue Scout" && item.only  == "amazon" && (item.type == "bow" || item.type == "crossbow")){
-                            halt = 0;
-                        }
-                        if (className == "Iron Wolf" && item.only  == "sorceress"){
-                            halt = 0;
-                        }
-                        if (className == "Iron Wolf" && item.only  == "paladin"){
-                            halt = 0;
-                        }
-                        if (className === item.only){
-                            halt = 0;
-                        }
-                     }
-				 }
 				if (halt == 0) {
                     if (className == "clear") { halt = 1 }
                     if (typeof(item.not) != 'undefined') { for (let l = 0; l < item.not.length; l++) { if (item.not[l] == className) { halt = 1 } } }

--- a/season12/data/functions.js
+++ b/season12/data/functions.js
@@ -1391,27 +1391,6 @@ function loadItems(group, dropdown, className) {
 			var item = equipment[group][itemNew];
 			// || item.only == className) {
 				var halt = 0;
-				if(typeof(item.only) != 'undefined'){
-                     if(item.only != className){
-                   //  console.log ("item.only "+item.only+" "+className)
-                        halt = 1;
-                        if (className == "Barb (merc)" && item.only  == "barbarian"){
-                            halt = 0;
-                        }
-                        if (className == "Rogue Scout" && item.only  == "amazon" && (item.type == "bow" || item.type == "crossbow")){
-                            halt = 0;
-                        }
-                        if (className == "Iron Wolf" && item.only  == "sorceress"){
-                            halt = 0;
-                        }
-                        if (className == "Iron Wolf" && item.only  == "paladin"){
-                            halt = 0;
-                        }
-                        if (className === item.only){
-                            halt = 0;
-                        }
-                     }
-				 }
 				if (halt == 0) {
                     if (className == "clear") { halt = 1 }
                     if (typeof(item.not) != 'undefined') { for (let l = 0; l < item.not.length; l++) { if (item.not[l] == className) { halt = 1 } } }


### PR DESCRIPTION
## Summary
- Removes the `only`-based class filter from the `loadItems` function in both `data/functions.js` and `season12/data/functions.js`
- Class-restricted weapons (e.g., sorceress orbs like Tal Rasha's Lidless Eye) now appear in the weapon dropdown regardless of selected class
- Merc weapon type restrictions (e.g., Iron Wolf can only use swords, orbs, scepters, maces) remain intact and already handle filtering correctly

Closes #86

## Context
In PD2, Act 3 mercenaries (Iron Wolf) can equip sorceress orbs. The `only: "sorceress"` property was hiding these items when a non-sorceress class was selected, preventing users from planning merc builds. The merc-specific weapon type filters on lines 1516-1520 already correctly restrict which weapon types each merc can equip, making the `only` filter redundant.

## Test plan
- [ ] Select a non-Sorceress class (e.g., Paladin) and verify Tal Rasha's Lidless Eye appears in the weapon dropdown
- [ ] Select Sorceress and verify orbs still appear
- [ ] Select Iron Wolf merc and verify orbs appear but claws do not
- [ ] Select other mercs and verify their weapon type restrictions still work
- [ ] Verify season12 planner also shows the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)