### PR TITLE
Fix #89: Fix incorrect base critical strike calculation

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -5821,10 +5821,13 @@ function updateSecondaryStats() {
 	var cs_data = skills_all["amazon"][11].data.values[0];
 	if (c.class_name == "Amazon") {
 		var cs_lvl = skills[11].level + skills[11].extra_levels;
-		if (cs_lvl > 0) { cstrike_skill = cs_data[cs_lvl] || 0; }
+		if (cs_lvl > 0 && (skills[11].level > 0 || skills[11].force_levels > 0)) { cstrike_skill = cs_data[cs_lvl] || 0; }
 	} else {
-		var cs_lvl = ~~c.oskill_Critical_Strike + c.all_skills + Math.ceil(c.all_skills_per_level*c.level);
-		if (cs_lvl > 0) { cstrike_skill = cs_data[cs_lvl] || 0; }
+		var cs_oskill = ~~c.oskill_Critical_Strike;
+		if (cs_oskill > 0) {
+			var cs_lvl = cs_oskill + c.all_skills + Math.ceil(c.all_skills_per_level*c.level);
+			cstrike_skill = cs_data[cs_lvl] || 0;
+		}
 	}
 
 	document.getElementById("cstrike").innerHTML = c.cstrike + c.cstrike_skillup + cstrike_skill; if (c.cstrike > 0 || c.cstrike_skillup > 0 || cstrike_skill > 0) { document.getElementById("cstrike").innerHTML += "%" }


### PR DESCRIPTION
## Summary
- **Amazon class**: Critical Strike was being activated by +all skills items (e.g. Stone of Jordan) even when no skill points were allocated in Critical Strike. Fixed by requiring at least 1 hard point or force_levels before applying the skill.
- **Non-Amazon classes**: The oskill Critical Strike path was also granting critical strike from +all skills alone (without the oskill). Fixed to require the oskill before applying all_skills bonus.

## Root cause
The critical strike calculation at line 5823 in `data/functions.js` used `skills[11].level + skills[11].extra_levels` to determine the skill level, but `extra_levels` includes +all skills bonuses. Since +all skills should not activate a skill with 0 base points, the check now also verifies that the skill has hard points or force_levels allocated.

## Test plan
- [ ] Load the URL from the issue (Amazon, level 1, no skills, only SoJ equipped) and verify critical strike no longer appears
- [ ] Equip SoJ on a non-Amazon class and verify no critical strike appears
- [ ] Allocate a point in Critical Strike on Amazon with SoJ and verify the +all skills bonus still applies correctly
- [ ] Test oskill Critical Strike on a non-Amazon class to verify it still works

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)