### PR TITLE
Fix #89: Fix passive skills activating from +all skills with 0 hard points

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -5869,7 +5869,7 @@ function updateSecondaryStats() {
 	if (c.class_name == "Barbarian") {
 		var dw_skill = skills[12];
 		var dw_lvl = dw_skill.level + dw_skill.extra_levels;
-		if (dw_lvl > 0) {
+		if (dw_lvl > 0 && (dw_skill.level > 0 || dw_skill.force_levels > 0)) {
 			dw_owounds = dw_skill.data.values[1][dw_lvl] || 0;
 			dw_owounds_dps = Math.floor((dw_skill.data.values[0][dw_lvl] || 0) * (1 + 0.04*skills[7].level));
 		}


### PR DESCRIPTION
## Summary
- Fixes Deep Wounds (Barbarian passive) showing open wounds % and DPS when +all skills items (e.g. SoJ) are equipped but no hard points are invested
- Same bug pattern as Critical Strike fix (PR #90) — `extra_levels` from +all skills was causing `dw_lvl > 0` even with 0 skill points
- Added guard: `(dw_skill.level > 0 || dw_skill.force_levels > 0)` so the passive only activates with actual skill investment or specific +skill items

## Audit of all passive skill calculations
- **Critical Strike (Amazon)** — already fixed in PR #90 ✓
- **Deep Wounds (Barbarian)** — fixed in this PR ✓
- **Penetrate (Amazon)** — already uses `skills[s].level > 0` guard ✓
- **Cleansing/Meditation synergies (Paladin)** — already uses `Math.min(1, level+force_levels)` guard ✓
- **Enflame/Fire Mastery synergies (Sorceress)** — already uses `Math.min(1, level+force_levels)` guard ✓
- **Iron Skin / Natural Resistance (Barbarian)** — go through effect system which gates on `level > 0 || force_levels > 0` ✓

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)