### PR TITLE
Fix #110: Display Life/Mana After Each Kill below Critical Strike

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -5884,6 +5884,28 @@ function updateSecondaryStats() {
 		document.getElementById("cdamage_total_label").style.display = "none";
 	}
 
+	// Life After Each Kill total
+	var life_per_kill_total = c.life_per_kill;
+	if (c.life_per_demon_kill > 0) {
+		document.getElementById("life_per_kill_total").innerHTML = life_per_kill_total + " , " + c.life_per_demon_kill + " (demons)";
+	} else {
+		document.getElementById("life_per_kill_total").innerHTML = life_per_kill_total;
+	}
+	if (life_per_kill_total > 0 || c.life_per_demon_kill > 0) {
+		document.getElementById("life_per_kill_total_label").style.display = "block";
+	} else {
+		document.getElementById("life_per_kill_total_label").style.display = "none";
+	}
+
+	// Mana After Each Kill total
+	var mana_per_kill_total = c.mana_per_kill;
+	document.getElementById("mana_per_kill_total").innerHTML = mana_per_kill_total;
+	if (mana_per_kill_total > 0) {
+		document.getElementById("mana_per_kill_total_label").style.display = "block";
+	} else {
+		document.getElementById("mana_per_kill_total_label").style.display = "none";
+	}
+
 	// Deep Wounds (Barbarian passive) open wounds contribution
 	var dw_owounds = 0;
 	var dw_owounds_dps = 0;

--- a/index.html
+++ b/index.html
@@ -970,6 +970,8 @@
 					<font size="2" id="ddamage_total_label">Deadly Damage: <font size="2" id="ddamage_total"></font><br></font>
 					<font size="2" id="cstrike_total_label">Critical Strike: <font size="2" id="cstrike_total"></font><br></font>
 					<font size="2" id="cdamage_total_label">Crit Damage: <font size="2" id="cdamage_total"></font><br></font>
+					<font size="2" id="life_per_kill_total_label">Life After Each Kill: <font size="2" id="life_per_kill_total"></font><br></font>
+					<font size="2" id="mana_per_kill_total_label">Mana After Each Kill: <font size="2" id="mana_per_kill_total"></font><br></font>
 					<font size="2" id="owounds_total_label">Open Wounds: <font size="2" id="owounds_total"></font><br></font>
 					<font size="2" id="owounds_damage_total_label">Open Wounds Damage: <font size="2" id="owounds_damage_total"></font><br></font>
 					<br/>


### PR DESCRIPTION
Closes #110

## Summary
Adds two new rows to the Path of Diablo secondary stats panel, displayed directly beneath the Critical Strike / Crit Damage rows:

- **Life After Each Kill** (id `life_per_kill_total`)
- **Mana After Each Kill** (id `mana_per_kill_total`)

## Files touched
- `index.html` (lines 973-974): two new `<font>` rows inserted between `cdamage_total_label` and `owounds_total_label`, mirroring the exact markup of the sibling "total" rows.
- `data/functions.js` (inside `updateSecondaryStats`, after the Crit Damage total block at ~line 5887): compute-and-render logic for the two new IDs, mirroring the `cstrike_total` conditional-visibility pattern (hide the label when the value is 0, show when > 0).

### Before
```
Crit Damage: 250%
Open Wounds: ...
```

### After
```
Crit Damage: 250%
Life After Each Kill: 15
Mana After Each Kill: 6
Open Wounds: ...
```
(Both new rows are hidden when the values are 0, matching Crit/Deadly/Open Wounds behaviour.)

## Stat codes used
This repo does not use raw `item_killed_heal`/`item_killed_mana` codes in JS. The planner stores these stats on the character as `life_per_kill`, `mana_per_kill`, and `life_per_demon_kill` (confirmed in `data/items.js`, `data/items_equipment.js`, `data/export_d2s.js` exporter mapping `life_per_kill -> "Life after each Kill"`, and the existing primary-panel rendering at `data/functions.js:5929-5930`). The new code reuses `c.life_per_kill` and `c.mana_per_kill` directly, so data already wired into every item, rune, jewel and set bonus picks up automatically. Demon-only LPK bonus is preserved in the `", N (demons)"` format already used by the primary panel.

Label text: full "Life After Each Kill" / "Mana After Each Kill" (matches the verbose convention used by neighbouring rows such as "Open Wounds Damage" and "Deadly Damage" in the same column).

## Test plan
- [x] `npm test` -> 32 passed / 0 failed (all data-integrity and skill-data tests).
- [ ] Manually load `index.html`, equip Grief / Death's Web / a LPK jewel, and confirm the two rows appear with correct totals.
- [ ] Confirm the two rows are hidden when no LPK/MPK gear is equipped.