### PR TITLE
Fix #114: rename "Damage Reduced by" to "Physical Damage Taken Reduced by" in build export

### DIFF
--- a/data/export_d2s.js
+++ b/data/export_d2s.js
@@ -122,8 +122,8 @@ var propKeyToText = {
 	defense_bonus: function(v) { return v + "% Enhanced Defense" },
 	defense_per_level: function(v) { return "+" + v + " Defense (Based on Character Level)" },
 	block: function(v) { return v + "% Increased Chance of Blocking" },
-	pdr: function(v) { return "Damage Reduced by " + v + "%" },
-	damage_reduced: function(v) { return "Damage Reduced by " + v },
+	pdr: function(v) { return "Physical Damage Taken Reduced by " + v + "%" },
+	damage_reduced: function(v) { return "Physical Damage Taken Reduced by " + v },
 	mDamage_reduced: function(v) { return "Magic Damage Reduced by " + v },
 
 	// Absorb


### PR DESCRIPTION
## Summary
Refs #114.

The build-export emitter in `data/export_d2s.js` produced prop strings labeled `Damage Reduced by N` and `Damage Reduced by N%`, which don't match the canonical PD2 stat label `Physical Damage Taken Reduced by ...` used everywhere else in the planner (see `data/item_metadata.js` lines 672-673). Downstream tooling that re-parses an exported build therefore failed on these props.

This PR updates the `pdr` and `damage_reduced` formatters in `data/export_d2s.js` to emit `Physical Damage Taken Reduced by N%` and `Physical Damage Taken Reduced by N` respectively, matching `item_metadata.js`.

## Not addressed in this PR
The issue also reports `Error: unknown item:` and `Error: unable to parse prop:` (with no specific item or prop). The "unable to parse prop" error is plausibly the same root cause as the rename above and should be fixed by this PR, but the "unknown item" report has no repro info. I've left a comment on #114 asking the author for a specific build/item that triggers the unknown-item error so it can be investigated as a follow-up. Using `Refs #114` (not `Closes`) so the issue stays open until that piece is confirmed.

## Test plan
- [ ] Export a build whose gear has Physical Damage Reduction (e.g. a Stormshield, Shaftstop, or +N PDR small charm)
- [ ] Confirm exported `.d2s`/JSON contains `Physical Damage Taken Reduced by N%` / `Physical Damage Taken Reduced by N` instead of `Damage Reduced by ...`
- [ ] Re-import the exported file (or feed it to whatever tool D-E-D uses) and confirm `unable to parse prop` no longer fires for the PDR lines

Generated with [Claude Code](https://claude.com/claude-code)