### PR TITLE
Fix #116: correct Annihilus charm stats to PD2 values

### DIFF
--- a/data/items.js
+++ b/data/items.js
@@ -45,7 +45,7 @@ var unequipped = {			strength:0, dexterity:0, vitality:0, energy:0, life:0, mana
 /*
     charms: [
 {name:"Charms"},
-{name:"Annihilus", size:"small", req_level:80, all_skills:1, all_attributes:20, all_res:20, experience:10},
+{name:"Annihilus", size:"small", req_level:80, all_skills:1, vitality:60, energy:20, all_res:20, experience:10},
 {name:"Hellfire Torch", size:"large", req_level:75, skills_class:2, vitality:60, energy:20, all_res:20, light_radius:8},
 {name:"Gheed's Fortune", size:"grand", req_level:62, gf:160, mf:40, discount:15},
 {only:"amazon", rarity:"magic", name:"+1 Harpoonist's Grand Charm", size:"grand", req_level:42, skills_javelins:1},

--- a/data/items_equipment.js
+++ b/data/items_equipment.js
@@ -889,8 +889,8 @@ ring1: [
  {name:"Charms"},
  // Unique
  {name:"Hellfire Torch", size:"large", req_level:75, skills_class:2, vitality:60, energy:20, all_res:20, light_radius:8},
- {name:"Annihilus", size:"small", req_level:80, all_skills:1, all_attributes:20, all_res:20, experience:10},
- {name:"Annihilus +2", size:"small", req_level:80, all_skills:2, all_attributes:20, all_res:20, experience:10},
+ {name:"Annihilus", size:"small", req_level:80, all_skills:1, vitality:60, energy:20, all_res:20, experience:10},
+ {name:"Annihilus +2", size:"small", req_level:80, all_skills:2, vitality:60, energy:20, all_res:20, experience:10},
  {name:"Gheed's Fortune", size:"grand", req_level:62, gf:160, mf:40, discount:15},
  // Large
  {rarity:"magic", name:"+3% Conduit Large Charm", size:"large", req_level:42, lDamage:3, pd2:1},

--- a/src/CharmsData.txt
+++ b/src/CharmsData.txt
@@ -125,8 +125,8 @@
  {only:"sorceress", rarity:"magic", name:"+1 Sparking Grand Charm + frw", size:"grand", req_level:42, skills_lightning:1, frw: 7},
  {only:"sorceress", rarity:"magic", name:"+1 Sparking Grand Charm + life", size:"grand", req_level:42, skills_lightning:1, life: 45},
  // Small
- {name:"Annihilus", size:"small", req_level:80, all_skills:1, all_attributes:20, all_res:20, experience:10},
- {name:"Annihilus +2", size:"small", req_level:80, all_skills:2, all_attributes:20, all_res:20, experience:10},
+ {name:"Annihilus", size:"small", req_level:80, all_skills:1, vitality:60, energy:20, all_res:20, experience:10},
+ {name:"Annihilus +2", size:"small", req_level:80, all_skills:2, vitality:60, energy:20, all_res:20, experience:10},
  {rarity:"magic", name:"Amber Small Charm of Vita", size:"small", req_level:39, lRes:11, life:20, pd2:1},
  {rarity:"magic", name:"Emerald Small Charm of Vita", size:"small", req_level:39, pRes:11, life:20, pd2:1},
  {rarity:"magic", name:"Fine Small Charm of Balance", size:"small", req_level:29, damage_max:3, ar:20, fhr:5, pd2:1},


### PR DESCRIPTION
Closes #116

## Summary
The planner was using vanilla D2 Annihilus stats (`all_attributes:20`, giving +20 Str/Dex/Vit/Energy) instead of the PD2 version, which drops Str/Dex in favor of more Vitality.

Per `data/UniqueItems.txt` (line 384, the authoritative PD2 source):
- `+1 to All Skills`
- `+30-60 Vitality`
- `+10-20 Energy`
- `All Resistances +10-20`
- `+5-10% Experience Gained`

This matches what the issue author (SirNahka) reported.

## Changes
Replaced `all_attributes:20` with `vitality:60, energy:20` (max-roll values, matching the convention used for Hellfire Torch in the same files) for both `Annihilus` and `Annihilus +2` in:
- `data/items_equipment.js` (the active charm list rendered by the planner)
- `data/items.js` (commented-out template/reference block, kept in sync to avoid future confusion)
- `src/CharmsData.txt` (source snippet used to regenerate the charm list)

The `season12/` directory is intentionally left untouched — it is the frozen previous-season snapshot.

## Follow-up (other repo)
The issue author also notes that the Mid-game / End-game Holy Bolt / FOH Paladin entries on the Solo Tier List need their strength budgets adjusted now that Anni no longer grants +20 Str. The Solo Tier List is not maintained in this repo (it lives in Hiim-PD2-Resources), so a follow-up there may be needed.

## Test plan
- [ ] Load the planner, equip Annihilus on a small charm slot, and verify it grants +1 All Skills, +60 Vit, +20 Energy, +20 All Res, +10% XP (no Str/Dex bonus).
- [ ] Repeat with Annihilus +2 and verify the same stats with +2 All Skills.
- [ ] Confirm that existing builds that previously assumed Anni Str/Dex (e.g. saves/pod_85_holy_din.txt) no longer meet strength reqs for some gear — expected and matches the in-game truth.