### PR TITLE
Fix effective defense to include item's own ED roll

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -4549,7 +4549,9 @@ function getItemEffectiveStatsLines(source, sockTotals, corrSource) {
 	var bDef = ~~source.base_defense;
 	if (bDef > 0) {
 		var multEth = (source.ethereal == 1) ? 1.25 : 1;
-		var itemEDef = ~~source.e_def + sockEDef + corrEDef;
+		// Unique armors store their own ED roll in defense_bonus (e.g. Shaftstop 220).
+		// Sockets/runes/affixes use e_def. Both contribute to per-item effective defense.
+		var itemEDef = ~~source.e_def + ~~source.defense_bonus + sockEDef + corrEDef;
 		var flatDef = ~~source.defense;
 		var effDef = Math.ceil(multEth * (1 + itemEDef/100) * bDef) + flatDef;
 		lines += "Defense: " + effDef + "<br>";


### PR DESCRIPTION
Follow-up to #120.

## The bug

Unique armors (Shaftstop, Templar's Might, Tyrael's Might, Skin of the Vipermagi, Arkaine's Valor, Andariel's Visage, etc.) store their Enhanced Defense % in `defense_bonus`, not `e_def`. The new effective Defense line introduced for #119 was only summing `e_def`, so the per-item armor display didn't reflect the armor's own ED — it looked basically the same as base defense.

Weapons were unaffected because weapons use `e_damage`, which the helper reads correctly.

## The fix

In `getItemEffectiveStatsLines` armor branch, sum `defense_bonus` alongside `e_def`:

```js
var itemEDef = ~~source.e_def + ~~source.defense_bonus + sockEDef + corrEDef;
```

Sockets/runes still use `e_def` (Pul/Um/etc. and runeword socket totals), corruptions still use `e_def` from `corrSource.e_def`, and now the item's own roll from `defense_bonus` is included too. All four sources sum into the per-armor multiplier.

## Spot-check expectation

- Shaftstop (Mesh Armor base ~108-178, defense_bonus 220):
  - Before: shown as basically base defense (e_def = 0)
  - After: ~3.2x base defense
- Sacred Armor with no uniques: unchanged (no defense_bonus)
- Stone runeword (Mesh): existing e_def from runes still works as before, plus any defense_bonus from runes

## Not in this PR

- Set bonuses (`set_bonuses[i].e_def`) still aren't pulled into the per-item line. The per-character total at `updatePrimaryStats` (line ~5550) does include them, but the per-item helper does not. Out of scope here unless it turns out to matter visually.
- Weapon side untouched — looks right per user testing.

## Verification

- `npm test` 32/32 pass
- `node --check data/functions.js` clean