### PR TITLE
Fix #126: Add Blood Craft Phys and Brilliant Craft Phys rings

### DIFF
--- a/data/items_equipment.js
+++ b/data/items_equipment.js
@@ -976,8 +976,10 @@ amulet: [
 ring1: [
 {name:"Ring"},
     {req_level: 12, name: "Angelic Halo", rarity: "set", set_Angelic: 1, set_bonuses: ["set_Angelic", {},     {ar_per_level: 3.0},     {mf: 50},     {},     {},     {}], life_replenish: 6, life: 20},
+    {req_level: 5, rarity: "craft", name: "Blood Craft Ring (Phys)", strength: 10, life_leech: 3, life: 20, damage_min: 13, damage_max: 14},
     {req_level: 5, rarity: "craft", name: "Brilliant Craft Ring", all_res: 5, half_freeze: 1},
     {req_level: 5, rarity: "craft", name: "Brilliant Craft Ring + FCR", all_res: 5, half_freeze: 1, fcr: 10},
+    {req_level: 5, rarity: "craft", name: "Brilliant Craft Ring (Phys)", all_res: 5, half_freeze: 1, damage_min: 13, damage_max: 14},
     {req_level: 58, name: "Bul Katho's Wedding Band", life_per_level: 0.5, all_skills: 1, life_leech: 6, stamina: 50},
     {req_level: 69, name: "Bul-Kathos' Death Band", rarity: "set", set_BK: 1, set_bonuses: ["set_BK", {},     {cbf: 1},     {},     {},     {},     {}], e_damage: 30, ar: 100, lRes: 25, pdr: 8},
     {req_level: 60, name: "Carrion Wind", missile_defense: 160, life_leech: 9, pRes: 55, thorns: 300, charges_skill: "Carrion Vine", charges_charges: 35, charges_level: 11, strike_skill: "Twister", strike_chance: 8, strike_level: 30, frw: 20},

--- a/data/magicrarerw.tsv
+++ b/data/magicrarerw.tsv
@@ -215,6 +215,8 @@ Beast - Caduceus	Scepter	Caduceus	rw		Runeword	Beast			ethereal		1	1
 Echo Quiver - Sharp Arrows	Quiver	Sharp Arrows	rw		Runeword	Echo Quiver																										
 Brilliant Craft Ring	Jewelry	Ring	craft		all_res			5	half_freeze		1	1																				
 Brilliant Craft Ring + FCR	Jewelry	Ring	craft		all_res			5	half_freeze		1	1	fcr		10	10																
+Blood Craft Ring (Phys)	Jewelry	Ring	craft		strength		10	10	life_leech		3	3	life		20	20	damage_min		13	13	damage_max		14	14								
+Brilliant Craft Ring (Phys)	Jewelry	Ring	craft		all_res			5	half_freeze		1	1	damage_min		13	13	damage_max		14	14												
 Dual Leech Ring	Jewelry	Ring	rare		life_leech		8	8	mana_leech		5	5																				
 Doom - Berserker Axe	Axe	Berserker Axe	rw		Runeword	Doom			ethereal		1	1																				
 Phoenix - Aegis	Shield	Aegis	rw		Runeword	Phoenix																										


### PR DESCRIPTION
## Summary

Adds two new crafted ring entries requested in #126.

### Files changed
- `data/items_equipment.js` — added two ring entries in the `ring1` block (alphabetical position next to existing Brilliant Craft Ring entries)
- `data/magicrarerw.tsv` — added matching source rows (rows 218 and 219) so the Java `UpdateUniqueItemsStats` regenerator stays in sync

### New entries

**Blood Craft Ring (Phys)** — req_level 5, rarity craft
```js
{req_level: 5, rarity: "craft", name: "Blood Craft Ring (Phys)", strength: 10, life_leech: 3, life: 20, damage_min: 13, damage_max: 14}
```
- `strength: 10` → +10 STR
- `life_leech: 3` → 3% Life Leech (see judgment call below)
- `life: 20` → +20 to Life
- `damage_min: 13`, `damage_max: 14` → 13-14 min/max damage

**Brilliant Craft Ring (Phys)** — req_level 5, rarity craft
```js
{req_level: 5, rarity: "craft", name: "Brilliant Craft Ring (Phys)", all_res: 5, half_freeze: 1, damage_min: 13, damage_max: 14}
```
- `all_res: 5` → 5% All Resistances
- `half_freeze: 1` → Half Freeze Duration
- `damage_min: 13`, `damage_max: 14` → 13-14 min/max damage

### Judgment call: "3% light leech"

The issue body said `3% light leech` for the Blood craft. There is **no `light_leech` (lightning leech) field anywhere in the codebase**, and Blood Craft is canonically the life-leech themed craft in PD2. I read this as a typo for "**life leech**" and used `life_leech: 3`, matching the field name used by other rings (e.g. Bul Katho's Wedding Band, Dual Leech Ring).

If you actually meant lightning damage on attack (e.g. `lDamage_min`/`lDamage_max`) or something else, say the word and I'll swap it.

### Field naming notes
- `damage_min`/`damage_max` matches the convention used by every existing weapon/jewelry entry that has fixed min/max physical damage (Bartuc's Cut Throat, Aldur's Rhythm, etc.).
- I picked `req_level: 5` to match the existing Brilliant Craft Ring entries.
- `(Phys)` suffix in the name is to distinguish the new physical-damage variant from the existing Brilliant Craft Ring / Brilliant Craft Ring + FCR.

### Test plan

- [ ] Open the planner, select a ring slot, confirm both new entries appear in the Ring dropdown
- [ ] Select Blood Craft Ring (Phys), verify +10 STR, 3% Life Leech, +20 Life, +13/+14 damage all show up correctly in the stat panel
- [ ] Select Brilliant Craft Ring (Phys), verify 5% All Res, Half Freeze, +13/+14 damage show up
- [ ] Confirm the `life_leech` interpretation matches your intent

Closes #126