### PR TITLE
Fix eureka export prop-format mismatches (mana-per-kill et al.)

### DIFF
--- a/data/export_d2s.js
+++ b/data/export_d2s.js
@@ -106,7 +106,7 @@ var propKeyToText = {
 
 	// Misc combat
 	cblow: function(v) { return v + "% Chance of Crushing Blow" },
-	dstrike: function(v) { return v + "% Deadly Strike" },
+	dstrike: function(v) { return v + "% Chance of Deadly Strike" },
 	owounds: function(v) { return v + "% Chance of Open Wounds" },
 	pmh: function(v) { return "Prevent Monster Heal" },
 	itd: function(v) { return "Ignore Target's Defense" },
@@ -124,12 +124,14 @@ var propKeyToText = {
 	block: function(v) { return v + "% Increased Chance of Blocking" },
 	pdr: function(v) { return "Physical Damage Taken Reduced by " + v + "%" },
 	damage_reduced: function(v) { return "Physical Damage Taken Reduced by " + v },
-	mDamage_reduced: function(v) { return "Magic Damage Reduced by " + v },
+	mDamage_reduced: function(v) { return "Magic Damage Taken Reduced by " + v },
 
 	// Absorb
-	fAbsorb: function(v) { return v + "% Fire Absorb" },
-	cAbsorb: function(v) { return v + "% Cold Absorb" },
-	lAbsorb: function(v) { return v + "% Lightning Absorb" },
+	// Percent absorb grammar expects "<element> Absorb N%"; the flat variants
+	// keep the leading "+N Element Absorb" wording.
+	fAbsorb: function(v) { return "Fire Absorb " + v + "%" },
+	cAbsorb: function(v) { return "Cold Absorb " + v + "%" },
+	lAbsorb: function(v) { return "Lightning Absorb " + v + "%" },
 	fAbsorb_flat: function(v) { return "+" + v + " Fire Absorb" },
 	cAbsorb_flat: function(v) { return "+" + v + " Cold Absorb" },
 	lAbsorb_flat: function(v) { return "+" + v + " Lightning Absorb" },
@@ -143,12 +145,17 @@ var propKeyToText = {
 	experience: function(v) { return "+" + v + "% to Experience Gained" },
 	life_replenish: function(v) { return "Replenish Life +" + v },
 	life_per_kill: function(v) { return "+" + v + " Life after each Kill" },
-	mana_per_kill: function(v) { return "+" + v + " Mana after each Kill" },
+	// "to Mana" is required by the eureka grammar (item_manaafterkill rule);
+	// life_per_kill has no "to" because item_healafterkill omits it. See
+	// ProjectDiablo2PropGrammar.g4 lines 119 and 189.
+	mana_per_kill: function(v) { return "+" + v + " to Mana after each Kill" },
 	life_per_hit: function(v) { return "+" + v + " Life after each Hit" },
+	// NOTE: eureka has no item_manaafterhit grammar rule, so this string
+	// cannot be parsed by the external tool. Left as-is until PD2 adds the stat.
 	mana_per_hit: function(v) { return "+" + v + " Mana after each Hit" },
 	thorns: function(v) { return "Attacker Takes Damage of " + v },
 	thorns_per_level: function(v) { return "Attacker Takes Damage of " + v + " (Based on Character Level)" },
-	damage_to_mana: function(v) { return v + "% Damage Taken Goes to Mana" },
+	damage_to_mana: function(v) { return v + "% Damage Taken Gained as Mana when Hit" },
 	req: function(v) { return "Requirements " + v + "%" },
 	sockets: function(v) { return "Socketed (" + v + ")" },
 	indestructible: function(v) { return "Indestructible" },
@@ -163,7 +170,7 @@ var propKeyToText = {
 
 	// Regen
 	mana_regen: function(v) { return "Regenerate Mana " + v + "%" },
-	pierce: function(v) { return v + "% chance of Piercing Attack" },
+	pierce: function(v) { return v + "% Chance to Pierce" },
 };
 
 // Keys to skip when building property text (these are metadata, not D2 properties)


### PR DESCRIPTION
Follow-up to #129. After that PR landed, exporting and pasting into bug-free-eureka surfaced:

> `Error: unable to parse prop: +6 Mana after each Kill`

The eureka grammar is asymmetric — `item_healafterkill` accepts `+N life after each kill` (no `to`), but `item_manaafterkill` requires `+N to mana after each kill` (with `to`). Our exporter emitted the no-`to` form for both, so life worked and mana threw.

I audited every entry in `propKeyToText` against `ProjectDiablo2PropGrammar.g4` and the `metaParse` regex fallbacks in `bug-free-eureka/rip2d2s.js`. Six mismatches found, not just the one that triggered the alert.

## Fixed

| Key | Before | After | Why |
|---|---|---|---|
| `mana_per_kill` | `+N Mana after each Kill` | `+N to Mana after each Kill` | grammar requires `to` |
| `dstrike` | `N% Deadly Strike` | `N% Chance of Deadly Strike` | `item_deadlystrike` requires `chance of` |
| `pierce` | `N% chance of Piercing Attack` | `N% Chance to Pierce` | `item_pierce` exact phrasing |
| `mDamage_reduced` | `Magic Damage Reduced by N` | `Magic Damage Taken Reduced by N` | grammar requires `taken` |
| `damage_to_mana` | `N% Damage Taken Goes to Mana` | `N% Damage Taken Gained as Mana when Hit` | `item_damagetomana` exact phrasing |
| `fAbsorb` / `cAbsorb` / `lAbsorb` | `N% <Elem> Absorb` | `<Elem> Absorb N%` | eureka was silently matching the leading `N%` against the flat-absorb rule and importing as flat absorb instead of percent — **silent data corruption, not just a parse error** |

## Left alone (no clean eureka equivalent — flagged in commit body)

- `mana_per_hit` — eureka has `item_healafterhit` but no `item_manaafterhit` rule
- `min_damage_per_level` — eureka has `item_maxdamage_perlevel` but no mindamage variant
- `sockets` — `propKeyToText` entry is unreachable; sockets are encoded via `ripItem.sockets` array, not the props array

## Test plan

- [ ] Load the URL from #128, click Export → Copy & Open Export Tool, paste into eureka — no `unable to parse prop` errors
- [ ] Build with an item carrying mana-per-kill exports cleanly
- [ ] Build with %-absorb (e.g. Wisp Projector) exports as %-absorb in eureka, not flat absorb

🤖 Generated with [Claude Code](https://claude.com/claude-code)