### PR TITLE
Fix #128 follow-up: derive eureka base names for amulets, rings, charms

### DIFF
--- a/data/export_d2s.js
+++ b/data/export_d2s.js
@@ -301,19 +301,50 @@ function getItemRarity(item) {
 }
 
 
+// Map a charm's "size" field to the eureka base-item name.
+// Eureka rip2d2s parses `type` as "<Rarity> <Base>" and looks up <Base> in
+// nameToItemEntry, which is keyed by the readable namestr of each item code
+// (cm1 = "Small Charm", cm2 = "Large Charm", cm3 = "Grand Charm"). See
+// bug-free-eureka/rip2d2s.js:849-851 (rejuv.base parse) and 1057-1070
+// (nameToItemEntry construction).
+var charmSizeToBase = {
+	small: "Small Charm",
+	large: "Large Charm",
+	grand: "Grand Charm"
+};
+
+// Derive the base item name for items whose data entries omit `base:`.
+// Amulets, rings, and charms in items_equipment.js are all defined without a
+// `base` field because their slot uniquely determines the base item code. The
+// previous fallback used item.name as the base, which produced strings like
+// "Unique Highlord's Wrath" and made eureka throw `unknown item: Highlord's
+// Wrath` at rip2d2s.js:1302.
+function deriveBaseFromSource(item, sourceArray) {
+	if (sourceArray === "amulet") return "Amulet";
+	if (sourceArray === "ring1" || sourceArray === "ring2") return "Ring";
+	if (sourceArray === "charms") {
+		var size = item.size;
+		if (size && charmSizeToBase[size]) return charmSizeToBase[size];
+	}
+	return "";
+}
+
 // Build a rip-format item from a planner equipment entry
 function buildRipItem(itemName, slotGroup) {
 	if (!itemName || itemName === "none") return null;
 
 	// Find the item in equipment arrays
-	var item = findEquipmentItem(itemName, slotGroup);
-	if (!item) return null;
+	var found = findEquipmentItem(itemName, slotGroup);
+	if (!found) return null;
+	var item = found.item;
 
-	// Get the base name
+	// Get the base name. Most items have an explicit `base` field; amulets,
+	// rings, and charms in items_equipment.js do not — derive their base from
+	// the equipment array (and `size` for charms) so the emitted `type`
+	// matches what eureka's nameToItemEntry table expects.
 	var baseName = item.base || "";
-	if (!baseName && typeof bases !== 'undefined') {
-		// For charms and other items without a base field
-		baseName = item.name;
+	if (!baseName) {
+		baseName = deriveBaseFromSource(item, found.sourceArray);
 	}
 
 	var rarity = getItemRarity(item);
@@ -360,19 +391,25 @@ function buildRipItem(itemName, slotGroup) {
 }
 
 
-// Find an equipment item by name across all equipment arrays
+// Find an equipment item by name across all equipment arrays. Returns
+// { item, sourceArray } so callers can derive a default base item name from
+// the array the entry came from (amulet → "Amulet", ring → "Ring", charms →
+// per-size charm base). Returns null if the item is not found.
 function findEquipmentItem(name, slotGroup) {
 	if (typeof equipment === 'undefined') return null;
 
-	// Search all equipment arrays
+	// Search all equipment arrays. ring2 is included for completeness even
+	// though the planner data file leaves ring2 empty (rings live under
+	// "ring1") — callers may still pass slotGroup "ring2".
 	var arrays = ["weapon", "helm", "armor", "offhand", "gloves", "boots", "belt",
-		"amulet", "ring1", "charms"];
+		"amulet", "ring1", "ring2", "charms"];
 
 	for (var a = 0; a < arrays.length; a++) {
-		var arr = equipment[arrays[a]];
+		var arrName = arrays[a];
+		var arr = equipment[arrName];
 		if (!arr) continue;
 		for (var i = 0; i < arr.length; i++) {
-			if (arr[i].name === name) return arr[i];
+			if (arr[i].name === name) return { item: arr[i], sourceArray: arrName };
 		}
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to merged #129 (cross-origin fix) and #130 (prop-format fix). After the planner finally produces valid JSON and eureka actually parses props, the next failure mode surfaced:

```
Error: unknown item: Highlord's Wrath
```

## Root cause

Items in `data/items_equipment.js` whose slot uniquely determines their base do not carry a `base:` field — this is true for **all 30 amulets, 18 rings, and 142 charms**. The previous fallback in `buildRipItem` was:

```js
var baseName = item.base || "";
if (!baseName && typeof bases !== 'undefined') {
    baseName = item.name;   // <-- wrong: emits "Highlord's Wrath" as base
}
```

That produces a `type` string like `"Unique Highlord's Wrath"`.

Eureka's `rip2d2s.js` parses `type` as `"<Rarity> <Base>"` ([`rip2d2s.js:849-851`](https://github.com/exiledagain/bug-free-eureka/blob/main/rip2d2s.js#L849-L851)) and looks `<Base>` up in `nameToItemEntry`, which is keyed by the readable `namestr` of each item code ([`rip2d2s.js:1057-1070`](https://github.com/exiledagain/bug-free-eureka/blob/main/rip2d2s.js#L1057-L1070)) — i.e. `"Amulet"`, `"Ring"`, `"Small Charm"`, `"Large Charm"`, `"Grand Charm"`. When the lookup misses it throws `unknown item: <name>` at [`rip2d2s.js:1302`](https://github.com/exiledagain/bug-free-eureka/blob/main/rip2d2s.js#L1302). That's the error.

## Ground truth

Verified the expected format against the real player rip dumps shipped with eureka under `examples/rip2d2s/`:

| Item | type |
|---|---|
| Mara's Kaleidoscope, Highlord's Wrath, Metalgrid | `Unique Amulet` |
| Wisp Projector, Raven Frost, The Stone of Jordan, Constricting Ring | `Unique Ring` |
| Hellfire Torch | `Unique Large Charm` |
| Annihilus | `Unique Small Charm` |
| Gheed's Fortune | `Unique Grand Charm` |
| Shimmering Small Charm of Vita | `Magic Small Charm` |

## Fix

`findEquipmentItem` now returns `{ item, sourceArray }`. When `item.base` is missing, `buildRipItem` derives the base from `sourceArray`:

- `amulet` → `Amulet`
- `ring1` / `ring2` → `Ring`
- `charms` + `item.size` → `Small Charm` / `Large Charm` / `Grand Charm`

This is universal — every no-base entry in the data file is now mapped correctly. The mapping is backed by the real example rip JSONs and by eureka's own `Misc.txt` (codes `amu`, `rin`, `cm1`, `cm2`, `cm3`).

`ring2` is also added to the search-array list (the planner data leaves `equipment.ring2` empty, but `buildRipJson` does pass slot `"ring2"`).

## Audit scope (from the issue URL + items raised in the follow-up)

**Fixed by this PR** (no `base` field):

- Amulets: Highlord's Wrath, Mara's, Metalgrid, Atma's Scarab, Saracen's Chance, Seraph's Hymn, Nokozan Relic, Crescent Moon, The Cat's Eye, The Eye of Etlich, The Mahim-Oak Curio, The Rising Sun, The Third Eye, all magic/set/craft amulets (Iratha's Collar, Cathan's Sigil, Tal Rasha's Adjudication, Tancred's Weird, Telling of Beads, Vidala's Snare, Civerb's Icon, Angelic Wings, Arcanna's Sign, plus the Blood Craft / Apprentice variants)
- Rings: Wisp Projector, Bul Katho's Wedding Band, The Stone of Jordan, Raven Frost, Manald Heal, Nagelring, Dwarf Star, Nature's Peace, Carrion Wind, Constricting Ring, Bul-Kathos' Death Band, Cathan's Seal, Angelic Halo, Dual Leech Ring, all Blood Craft / Brilliant Craft rings
- Charms: Hellfire Torch, Annihilus (and Annihilus +2), Gheed's Fortune, every small/large/grand magic charm

**Already OK** (have `base:`): Templar's Might, Doom's Finger, Dracul's Grasp, every Bone Visage entry (Giant Skull, Overlord's Helm, Trang-Oul's Guise + the runewords Dream/Ferocity/Flickering Flame/Nadir/Radiance/Wisdom), Wraithskin, Valkyrie Wing, War Traveler, Marrowwalk, Nosferatu's Coil, Ebonbane, etc.

The issue-#128 URL exercises six of the broken items at once (Highlord's Wrath, Wisp Projector, Bul Katho's Wedding Band, Annihilus +2, Hellfire Torch, Shimmering Small Charm of Vita) — all of which are covered.

## Notes

- One soft-fallback edge case remains, but is **not** the throw path: `Annihilus +2` is a planner-only name (the upgraded variant), so it won't match `nameToUniqueEntry["Annihilus"]`. Eureka silently falls back to file `0` for unknown unique names ([`rip2d2s.js:1414-1419`](https://github.com/exiledagain/bug-free-eureka/blob/main/rip2d2s.js#L1414-L1419)) — the item still writes successfully, the sprite/file field will just be off. Left as-is; can be addressed separately if it surfaces visually in-game.
- Debug-only charms (`{debug:1, name:"+5 skills", ...}`) have no `size` either; they'll still emit with an empty base and may break export. They're behind the debug flag and not user-facing, so left unhandled here.

## Test plan

- [ ] Load issue #128's URL in the planner, click **Export to Game File**, paste into bug-free-eureka, click Download — should produce a `.d2s` without "unknown item" errors.
- [ ] Verify the emitted `type` for each broken item is `"Unique Amulet"` / `"Unique Ring"` / `"Unique Small Charm"` / `"Unique Large Charm"` / `"Unique Grand Charm"` as appropriate (visible in the modal's textarea).
- [ ] Confirm no regression for items that already had a `base:` (load any character with helms/armors/weapons/etc. and export).

🤖 Generated with [Claude Code](https://claude.com/claude-code)