### PR TITLE
Audit every planner base name vs eureka; fix 8 mismatches (follow-up to #131)

### DIFF
--- a/data/export_d2s.js
+++ b/data/export_d2s.js
@@ -329,6 +329,60 @@ function deriveBaseFromSource(item, sourceArray) {
 	return "";
 }
 
+// Translation table mapping the planner's readable base names to the readable
+// names eureka's nameToItemEntry actually contains. Eureka builds that table
+// by walking Misc.txt / Weapons.txt / Armor.txt and resolving each entry's
+// `namestr` through patchstring.tbl, expansionstring.tbl, and string.tbl in
+// that order (StringResolver, d2data.js:1608-1637; eureka resolver wiring at
+// d2data.js:2145-2154; nameToItemEntry build at rip2d2s.js:1057-1070). The
+// throw site is rip2d2s.js:1300-1302.
+//
+// Every mapping below is backed by a direct lookup against eureka's data:
+//
+//   Arrows           → Blunt Arrows   (Misc.txt aqv,  namestr=aqv resolved by
+//                                       patchstring.tbl to "Blunt Arrows")
+//   Bolts            → Light Bolts    (Misc.txt cqv,  patchstring.tbl)
+//   Long Siege Bow   → Large Siege Bow (Weapons.txt 8l8, string.tbl);
+//                                       Cliffkiller is UniqueItems.txt code=8l8
+//   Martel De Fer    → Martel de Fer  (Weapons.txt 9gm, string.tbl;
+//                                       lowercase "de" — only the casing
+//                                       differs in PD2's data); The Gavel of
+//                                       Pain is UniqueItems.txt code=9gm
+//   Sacred Plate     → Sacred Armor   (Armor.txt uar, expansionstring.tbl);
+//                                       Innocence runeword body armor — eureka
+//                                       only knows "Sacred Armor"
+//   Silver Edged Axe → Silver-edged Axe (Weapons.txt 7ba, expansionstring.tbl;
+//                                       hyphenated, lowercase "edged"); Ethereal
+//                                       Edge is UniqueItems.txt code=7ba
+//   Succubae Skull   → Succubus Skull (Armor.txt nee, expansionstring.tbl);
+//                                       Boneflame is UniqueItems.txt code=nee
+//   Two Handed Sword → Two-Handed Sword (Weapons.txt 2hs, string.tbl; hyphen);
+//                                       Shadowfang is UniqueItems.txt code=2hs
+//
+// All 405 distinct `base:` values in data/items_equipment.js were checked
+// against the rebuilt nameToItemEntry map; the eight above are the only
+// mismatches. The remaining 397 base names already resolve correctly without
+// translation.
+var plannerBaseToEurekaBase = {
+	"Arrows":           "Blunt Arrows",
+	"Bolts":            "Light Bolts",
+	"Long Siege Bow":   "Large Siege Bow",
+	"Martel De Fer":    "Martel de Fer",
+	"Sacred Plate":     "Sacred Armor",
+	"Silver Edged Axe": "Silver-edged Axe",
+	"Succubae Skull":   "Succubus Skull",
+	"Two Handed Sword": "Two-Handed Sword"
+};
+
+// Translate a planner base name to the readable form eureka's nameToItemEntry
+// is keyed on. Returns the input unchanged for any base eureka already knows.
+function translateBaseForEureka(baseName) {
+	if (baseName && plannerBaseToEurekaBase[baseName]) {
+		return plannerBaseToEurekaBase[baseName];
+	}
+	return baseName;
+}
+
 // Build a rip-format item from a planner equipment entry
 function buildRipItem(itemName, slotGroup) {
 	if (!itemName || itemName === "none") return null;
@@ -346,6 +400,13 @@ function buildRipItem(itemName, slotGroup) {
 	if (!baseName) {
 		baseName = deriveBaseFromSource(item, found.sourceArray);
 	}
+
+	// Translate planner base names to the readable form eureka's lookup table
+	// uses. The planner's `base:` strings come from PD2's in-game labels, which
+	// differ in a handful of cases from the readable namestr eureka resolves
+	// off Misc/Weapons/Armor.txt + the .tbl string tables. See
+	// plannerBaseToEurekaBase above for the audited list of mismatches.
+	baseName = translateBaseForEureka(baseName);
 
 	var rarity = getItemRarity(item);
 	var socketCount = item.sockets || 0;


### PR DESCRIPTION
## Summary

Systematic follow-up to #131. The user asked to stop whack-a-moling and audit
**every** base the planner exports against eureka's `nameToItemEntry`. This PR
is that audit and the resulting fix.

- **405** distinct `base:` values in `data/items_equipment.js` were checked
  against the rebuilt `nameToItemEntry` map.
- **397** already match the readable namestr eureka resolves through
  `patchstring.tbl` → `expansionstring.tbl` → `string.tbl`.
- **8** mismatches — all now mapped in a documented translation table.
- **0** items dropped — every fix has a verified eureka equivalent.

## Root cause (more general than #131)

`nameToItemEntry` (rip2d2s.js:1057-1070) is keyed by
`resolver.readable(entry.namestr)`. The readable comes from PD2's actual
`.tbl` string tables — and patchstring.tbl in particular renames a handful of
items relative to vanilla D2. Pre-existing `base:` strings in the planner use
PD2's in-game labels, which sometimes differ from those readables. PR #131
only patched the no-base slots (amulet/ring/charm); items with an explicit
`base:` were untouched.

## Audit scope

| Category in `items_equipment.js`           | Entries | Status after this PR |
| ------------------------------------------ | ------- | -------------------- |
| weapon (swords, axes, maces, claws, bows, …) | many  | verified — see below |
| helm, armor, offhand, gloves, boots, belt  | many    | verified             |
| amulet (no-base path)                      | 67      | already fixed in #131 |
| ring1 (no-base path)                       | 18      | already fixed in #131 |
| charms (no-base path)                      | 156     | already fixed in #131 |
| quivers (`type: 'quiver'`, all in offhand) | 23      | **fixed here** — Arrows/Bolts translated |
| **Total distinct `base:` strings**         | **405** | 397 pass-through, 8 translated |

Runes ("Zod Rune"), gems ("Perfect Topaz"), and the `Jewel` sentinel used in
the sockets path all already resolve correctly (rip2d2s.js:846-858 special-cases
gems/jewels/runes before the type-string parse). Special merc-only bases
called out in the task (Bone Visage, Vortex Shield) — verified OK.

## The 8 mismatches

Each row cites the `.tbl` that supplies the readable eureka actually uses.

| Planner `base:`     | Eureka readable     | Code | Source                    | Hit by                       |
| ------------------- | ------------------- | ---- | ------------------------- | ---------------------------- |
| `Arrows`            | `Blunt Arrows`      | aqv  | patchstring.tbl           | 8 quivers + 2 rare templates |
| `Bolts`             | `Light Bolts`       | cqv  | patchstring.tbl           | 7 quivers                    |
| `Long Siege Bow`    | `Large Siege Bow`   | 8l8  | string.tbl                | Cliffkiller                  |
| `Martel De Fer`     | `Martel de Fer`     | 9gm  | string.tbl                | The Gavel of Pain            |
| `Sacred Plate`      | `Sacred Armor`      | uar  | expansionstring.tbl       | Innocence (rw body armor)    |
| `Silver Edged Axe`  | `Silver-edged Axe`  | 7ba  | expansionstring.tbl       | Ethereal Edge                |
| `Succubae Skull`    | `Succubus Skull`    | nee  | expansionstring.tbl       | Boneflame                    |
| `Two Handed Sword`  | `Two-Handed Sword`  | 2hs  | string.tbl                | Shadowfang                   |

(The unique-item ↔ base associations were cross-checked against
`UniqueItems.txt` — Cliffkiller is code=8l8, The Gavel of Pain is code=9gm,
Ethereal Edge is code=7ba, Boneflame is code=nee, Shadowfang is code=2hs.)

## Fix

`data/export_d2s.js` now defines `plannerBaseToEurekaBase` (all 8 mappings,
each documented with its eureka citation) and `translateBaseForEureka()`.
`buildRipItem` passes the resolved base through the translator immediately
before assembling the `type` string. Items not in the table pass through
unchanged.

The display-only `base = "Arrows"` lines in `data/functions.js` (3640, 3848,
4080, 4217 — flagged in the task description) were intentionally left
alone — they are tooltip-render paths and never reach the export.

## Verification

Reproduced eureka's `StringResolver` (Latin-1 parse of the PD2 `.tbl`
binary format, d2data.js:1488-1606) and rebuilt the full
code → readable map from
`bug-free-eureka/data/s13/global/excel/{patchstring,expansionstring,string}.tbl`.
Cross-checked every planner `base:` against the rebuilt map and confirmed
the 8-item rejection list. After the change the rejection list is empty.

## Test plan

- [ ] Load planner, equip Cliffkiller — Export to Game File → confirm no
  `unknown item` throw and verify the bow lands in inventory in eureka.
- [ ] Repeat with Shadowfang, The Gavel of Pain, Ethereal Edge, Boneflame,
  Innocence (Sacred Plate runeword) — all should round-trip.
- [ ] Equip any quiver (e.g. Doom's Finger / Aetherwing / Cliffkiller's
  paired quiver) — confirm the quiver exports and re-imports as a usable
  arrow quiver (`aqv` family).
- [ ] Regression: equip a previously-working item (Mara's Kaleidoscope,
  Hellfire Torch, Annihilus) — should still round-trip cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)