### PR TITLE
Fix #137: scrollable overflow for #controls_guide on small viewports

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -24,6 +24,8 @@
   left: 875px;
   top: 4px;
   right: 0;
+  height: calc(100dvh - 4px);
+  overflow-y: auto;
   color: white;
   font-size: 0.85em;
   line-height: 1.6em;


### PR DESCRIPTION
Closes #137

## Summary

On small viewports (e.g. when the browser bookmarks bar is visible), the `#controls_guide` panel (which is fixed-positioned in the top-right area) is clipped because nothing constrains its height or allows it to scroll.

This PR adds the two CSS properties suggested by the reporter (@ArtiChevski) in `data/style.css`:

- `height: calc(100dvh - 4px);` — constrains the panel to the dynamic viewport height (accounting for the 4px top offset).
- `overflow-y: auto;` — adds a vertical scrollbar when the content overflows.

Credit to @ArtiChevski for diagnosing the issue and providing the exact fix and before/after screenshots.

## Test plan

- [ ] Open the planner in a browser with the bookmarks bar visible — verify the controls guide is fully accessible via scroll.
- [ ] Open with the bookmarks bar hidden — verify no regression and no unnecessary scrollbar appears.